### PR TITLE
Fix shader for portrait mode viewports

### DIFF
--- a/src/camera360/camera360.gdshader
+++ b/src/camera360/camera360.gdshader
@@ -195,7 +195,7 @@ void fragment() {
 	if (view_ratio > 1.0) {
 		pos = get_transformation(vec2(uv.x - 0.5 * view_ratio, uv.y - 0.5) * 1.0);
 	} else {
-		pos = get_transformation(vec2(uv.x - 0.5 * view_ratio, uv.y - 0.5) * 1.0);
+		pos = get_transformation(vec2(uv.x - 0.5, uv.y - 0.5 * view_ratio) * 1.0);
 	}
 	if (pos == vec3(0.0, 0.0, 0.0)) {
 		ALBEDO = pos;


### PR DESCRIPTION
The two branches of the if that starts at line 195 of `camera360.gdshader` were identical. I changed the logic and the shader now behaves better when the viewport is taller than wide. The distortion used to get progressively less centered as the viewport's width diminished.

Before : 
![image](https://github.com/Cykyrios/Godot360/assets/117857232/ce322389-a2fb-4d0f-b07b-c09d5327c84f)
After : 
![image](https://github.com/Cykyrios/Godot360/assets/117857232/c9aac91f-0b4a-4d39-a1a8-f5c9c17a3d62)

These images were taken by activating the grid, switching to panini and increasing the fov to 230deg without any rotation of the camera