### PR TITLE
Add a Fulldome fisheye lens that can be used to create planetarium content

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Camera360"
 run/main_scene="res://src/demo_scene.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://src/icon.png"
 
 [debug]

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ The code is based on [these](https://github.com/shaunlebron/blinky) [repos](http
 * Cylindrical: What you would obtain if you flattened a cylinder
 * Equirectangular: General panorama projection
 * Mercator: Usually used for maps
+* Fulldome: An adaptation of the fisheye lens that conforms to a format used to do video projection in planetariums
 
 Note that I am no expert on those projections, you can find much more details about them from better sources.
 

--- a/src/camera360/camera360.gd
+++ b/src/camera360/camera360.gd
@@ -2,7 +2,7 @@ class_name Camera360
 extends Camera3D
 
 
-enum Lens {RECTILINEAR, PANINI, FISHEYE, STEREOGRAPHIC, CYLINDRICAL, EQUIRECTANGULAR, MERCATOR}
+enum Lens {RECTILINEAR, PANINI, FISHEYE, STEREOGRAPHIC, CYLINDRICAL, EQUIRECTANGULAR, MERCATOR, FULLDOME}
 
 @export_range(10, 360) var fovx := 150.0: set = set_fovx
 @export var lens := Lens.RECTILINEAR: set = set_lens

--- a/src/camera360/camera360.gdshader
+++ b/src/camera360/camera360.gdshader
@@ -89,7 +89,7 @@ vec3 fisheye_ray(vec2 p) {
 vec3 fulldome(vec2 p) {
 	// This will dezoom enough that we should get exactly
 	// all of the fov in the viewport
-	vec2 dezoomed = p*2.0;
+	vec2 dezoomed = p * 2.0;
 	// For fulldome output, we want to crop the ouput so that we only render
 	// the circle corresponding to the fov
 	if (length(dezoomed) > 1.0) {
@@ -98,6 +98,7 @@ vec3 fulldome(vec2 p) {
 	// If we are within the 1 unit circle, we want the fisheye perspective.
 	return fisheye_ray(dezoomed);
 }
+
 vec3 stereographic_inverse(vec2 p) {
 	float scale = 0.5;
 	float r = sqrt(p.x * p.x + p.y * p.y);

--- a/src/camera360/camera360.gdshader
+++ b/src/camera360/camera360.gdshader
@@ -86,7 +86,18 @@ vec3 fisheye_ray(vec2 p) {
 	float scale = fisheye_forward(vec2(0.0, radians(fovx) / 2.0)).x;
 	return fisheye_inverse(p * scale);
 }
-
+vec3 fulldome(vec2 p) {
+	// This will dezoom enough that we should get exactly
+	// all of the fov in the viewport
+	vec2 dezoomed = p*2.0;
+	// For fulldome output, we want to crop the ouput so that we only render
+	// the circle corresponding to the fov
+	if (length(dezoomed) > 1.0) {
+		return vec3(0.0, 0.0, 0.0);
+	}
+	// If we are within the 1 unit circle, we want the fisheye perspective.
+	return fisheye_ray(dezoomed);
+}
 vec3 stereographic_inverse(vec2 p) {
 	float scale = 0.5;
 	float r = sqrt(p.x * p.x + p.y * p.y);
@@ -167,6 +178,7 @@ vec3 get_transformation(vec2 uv) {
 		case 4: return(cylindrical_ray(uv));
 		case 5: return(equirectangular_ray(uv));
 		case 6: return(mercator_ray(uv));
+		case 7: return(fulldome(uv));
 	}
 }
 

--- a/src/demo_scene.gd
+++ b/src/demo_scene.gd
@@ -74,4 +74,6 @@ func update_projection_label() -> void:
 			proj = "Equirectangular"
 		Camera360.Lens.MERCATOR:
 			proj = "Mercator"
+		Camera360.Lens.FULLDOME:
+			proj = "Fulldome"
 	projection_label.text = "Lens: %s\nFoV: %d°" % [proj, camera.fovx]


### PR DESCRIPTION
This adds a `Fulldome` lens type to the camera 3d that adapts the fisheye projection so that its output conforms to the fulldome format commonly used by planetariums (see https://www.imersa.org/fulldome-file-specifications for more details). 

Moreover, this resolves [this issue](https://github.com/Cykyrios/Godot360/issues/1).